### PR TITLE
Use streams instead of strings for response and request data

### DIFF
--- a/Nest.swift
+++ b/Nest.swift
@@ -18,7 +18,7 @@ public protocol ResponseType {
 }
 
 public protocol InputStreamable {
-  func readBytes(count:int) -> [Int8]
+  func readBytes(count:Int) -> [Int8]
 }
 
 public protocol OutputStreamable {

--- a/Nest.swift
+++ b/Nest.swift
@@ -6,7 +6,7 @@ public protocol RequestType {
   var method:String { get }
   var path:String { get }
   var headers:[Header] { get }
-  var body:String? { get }
+  var body:InputStreamable { get }
 }
 
 
@@ -14,7 +14,15 @@ public protocol RequestType {
 public protocol ResponseType {
   var statusLine:String { get }
   var headers:[Header] { get }
-  var body:String? { get }
+  var body:OutputStreamable { get }
+}
+
+public protocol InputStreamable {
+  func readBytes(count:int) -> [Int8]
+}
+
+public protocol OutputStreamable {
+  func writeBytes(bytes:[Int8])
 }
 
 public typealias Application = RequestType -> ResponseType

--- a/Specification.md
+++ b/Specification.md
@@ -38,7 +38,7 @@ public protocol RequestType {
   var method:String { get }
   var path:String { get }
   var headers:[Header] { get }
-  var body:NSInputStream { get }
+  var body:InputStreamable { get }
 }
 ```
 
@@ -60,7 +60,7 @@ The request body.
 public protocol ResponseType {
   var statusLine:String { get }
   var headers:[Header] { get }
-  var body:NSOutputStream { get }
+  var body:OutputStreamable { get }
 }
 ```
 
@@ -75,4 +75,33 @@ The headers is an array of tuples containing the key and value for each HTTP hea
 #### Body (`NSOutputStream`)
 
 The response body 
+
+## OutputStreamable
+
+```swift
+public protocol OutputStreamable {
+    public func writeBytes([Int8] bytes);
+}
+```
+
+#### writeBytes
+
+Write bytes write the bytes passed to the output stream
+
+## InputStreamable
+
+```swift
+public protocol InputStreamable {
+    public func readBytes(count: Int) -> [Int8];
+}
+```
+
+#### readBytes
+
+Read a given amount of bytes from the input.
+If the given amount is not avaiable, the current thread will
+be blocked until it is.
+
+
+
 

--- a/Specification.md
+++ b/Specification.md
@@ -50,7 +50,7 @@ This is an HTTP status. It must be a string containing a 3-digit integer result 
 
 The headers is an array of tuples containing the key and value for each HTTP header for the server to send in the returned order.
 
-#### Body (`NSInputStream`)
+#### Body (`InputStreamable`)
 
 The request body.
 
@@ -72,7 +72,7 @@ This is an HTTP status. It must be a string containing a 3-digit integer result 
 
 The headers is an array of tuples containing the key and value for each HTTP header for the server to send in the returned order.
 
-#### Body (`NSOutputStream`)
+#### Body (`OutputStreamable`)
 
 The response body 
 
@@ -80,7 +80,7 @@ The response body
 
 ```swift
 public protocol OutputStreamable {
-    public func writeBytes([Int8] bytes);
+    func writeBytes(bytes: [Int8]);
 }
 ```
 
@@ -92,7 +92,7 @@ Write bytes write the bytes passed to the output stream
 
 ```swift
 public protocol InputStreamable {
-    public func readBytes(count: Int) -> [Int8];
+    func readBytes(count: Int) -> [Int8];
 }
 ```
 

--- a/Specification.md
+++ b/Specification.md
@@ -35,24 +35,78 @@ public typealias Header = (String, String)
 
 ```swift
 public protocol HttpInputStream {
-  public func readByte()  -> Byte;   // Reads one byte form the byte stream
-  public func readBytes() -> [Byte]; // Reads all the bytes until \r\n into a byte array
-  public func asString()  -> String; // Reads all content until \r\n, and converts it to a string
-  public func readLine()  -> String; // Reads a single line from the input stream
+  public func readByte()  -> Byte?;
+  public func readBytes() -> [Byte]?;
+  public func readBytes(size:int) -> [Byte]?;
+  public func asString()  -> String?;
+  public func readLine()  -> String?;
 }
 ```
+
+#### readByte
+
+Reads one byte from the input stream.
+If the end of the stream has been reached, `null` is returned.
+If the end of the stream has not been reached, but there is no more data,
+the current thread is blocked until a new `Byte` is recived.
+
+#### readBytes
+
+Reads all bytes from the input stream.
+If end of stream has not been recived, the current thread is blocked unit it is.
+
+#### readBytes(size:int)
+
+Reads `size` bytes from the input stream.
+If end of stream has not been recived, and there is not `size` amount of data in the stream,
+the current thread is blocked.
+
+If end of stream has been recived, but there is not `size` amount of data in the stream,
+the rest of the data is returned.
+
+This means that there is no guarantee that the returned byte array is `size` in length
+
+#### asString
+
+Reads all bytes in the input stream and converts them to a string.
+If end of stream has not been recived, the current thread is blocked unit it is.
+
+#### readLine
+
+Reads all bytes until the first line return or end of stream.
+Block the current thread neither a line return or end of stream has been recived.
 
 ## OutputStream
 
 ```swift
 public protocol HttpOutputStream {
-  public func writeByte(Byte byte);       // Write a single byte
-  public func writeBytes([Byte] bytes);   // Write a series of bytes
-  public func writeString(String string); // Write a string
-  public func flush();                    // Flush buffers
-  public func close();                    // Writes \r\n, flushes, and then closes.
+  public func writeByte(Byte byte);
+  public func writeBytes([Byte] bytes);
+  public func writeString(String string);
+  public func flush();
+  public func close();
 }
 ```
+
+#### writeByte
+
+write a byte to the output stream
+
+#### writeBytes
+
+write a series of bytes to the output stream
+
+#### writeString
+
+write a string to the output stream
+
+#### flush
+
+flush the output stream
+
+#### close
+
+Write \r\n to the output stream, flushes, then closes.
 
 ## RequestType
 

--- a/Specification.md
+++ b/Specification.md
@@ -31,83 +31,6 @@ from a client.
 public typealias Header = (String, String)
 ```
 
-## InputStream
-
-```swift
-public protocol HttpInputStream {
-  public func readByte()  -> Byte?;
-  public func readBytes() -> [Byte]?;
-  public func readBytes(size:int) -> [Byte]?;
-  public func asString()  -> String?;
-  public func readLine()  -> String?;
-}
-```
-
-#### readByte
-
-Reads one byte from the input stream.
-If the end of the stream has been reached, `null` is returned.
-If the end of the stream has not been reached, but there is no more data,
-the current thread is blocked until a new `Byte` is recived.
-
-#### readBytes
-
-Reads all bytes from the input stream.
-If end of stream has not been recived, the current thread is blocked unit it is.
-
-#### readBytes(size:int)
-
-Reads `size` bytes from the input stream.
-If end of stream has not been recived, and there is not `size` amount of data in the stream,
-the current thread is blocked.
-
-If end of stream has been recived, but there is not `size` amount of data in the stream,
-the rest of the data is returned.
-
-This means that there is no guarantee that the returned byte array is `size` in length
-
-#### asString
-
-Reads all bytes in the input stream and converts them to a string.
-If end of stream has not been recived, the current thread is blocked unit it is.
-
-#### readLine
-
-Reads all bytes until the first line return or end of stream.
-Block the current thread neither a line return or end of stream has been recived.
-
-## OutputStream
-
-```swift
-public protocol HttpOutputStream {
-  public func writeByte(Byte byte);
-  public func writeBytes([Byte] bytes);
-  public func writeString(String string);
-  public func flush();
-  public func close();
-}
-```
-
-#### writeByte
-
-write a byte to the output stream
-
-#### writeBytes
-
-write a series of bytes to the output stream
-
-#### writeString
-
-write a string to the output stream
-
-#### flush
-
-flush the output stream
-
-#### close
-
-Write \r\n to the output stream, flushes, then closes.
-
 ## RequestType
 
 ```swift
@@ -115,7 +38,7 @@ public protocol RequestType {
   var method:String { get }
   var path:String { get }
   var headers:[Header] { get }
-  var body:HttpInputStream { get }
+  var body:NSInputStream { get }
 }
 ```
 
@@ -127,9 +50,9 @@ This is an HTTP status. It must be a string containing a 3-digit integer result 
 
 The headers is an array of tuples containing the key and value for each HTTP header for the server to send in the returned order.
 
-#### Body (`HttpInputStream`)
+#### Body (`NSInputStream`)
 
-Must be an HttpInputStream. If the body is empty, the HttpInputStream is empty.
+The request body.
 
 ## ResponseType
 
@@ -137,7 +60,7 @@ Must be an HttpInputStream. If the body is empty, the HttpInputStream is empty.
 public protocol ResponseType {
   var statusLine:String { get }
   var headers:[Header] { get }
-  var body:HttpOutputStream { get }
+  var body:NSOutputStream { get }
 }
 ```
 
@@ -149,7 +72,7 @@ This is an HTTP status. It must be a string containing a 3-digit integer result 
 
 The headers is an array of tuples containing the key and value for each HTTP header for the server to send in the returned order.
 
-#### Body (`HttpOutputStream`)
+#### Body (`NSOutputStream`)
 
-Must be an HttpOutputStream.
+The response body 
 

--- a/Specification.md
+++ b/Specification.md
@@ -31,6 +31,29 @@ from a client.
 public typealias Header = (String, String)
 ```
 
+## InputStream
+
+```swift
+public protocol HttpInputStream {
+  public func readByte()  -> Byte;   // Reads one byte form the byte stream
+  public func readBytes() -> [Byte]; // Reads all the bytes until \r\n into a byte array
+  public func asString()  -> String; // Reads all content until \r\n, and converts it to a string
+  public func readLine()  -> String; // Reads a single line from the input stream
+}
+```
+
+## OutputStream
+
+```swift
+public protocol HttpOutputStream {
+  public func writeByte(Byte byte);       // Write a single byte
+  public func writeBytes([Byte] bytes);   // Write a series of bytes
+  public func writeString(String string); // Write a string
+  public func flush();                    // Flush buffers
+  public func close();                    // Writes \r\n, flushes, and then closes.
+}
+```
+
 ## RequestType
 
 ```swift
@@ -38,17 +61,7 @@ public protocol RequestType {
   var method:String { get }
   var path:String { get }
   var headers:[Header] { get }
-  var body:String? { get }
-}
-```
-
-### ResponseType
-
-```swift
-public protocol ResponseType {
-  var statusLine:String { get }
-  var headers:[Header] { get }
-  var body:String? { get }
+  var body:HttpInputStream { get }
 }
 ```
 
@@ -60,7 +73,29 @@ This is an HTTP status. It must be a string containing a 3-digit integer result 
 
 The headers is an array of tuples containing the key and value for each HTTP header for the server to send in the returned order.
 
-#### Body (`String?`)
+#### Body (`HttpInputStream`)
 
-The body must be a String or nil.
+Must be an HttpInputStream. If the body is empty, the HttpInputStream is empty.
+
+## ResponseType
+
+```swift
+public protocol ResponseType {
+  var statusLine:String { get }
+  var headers:[Header] { get }
+  var body:HttpOutputStream { get }
+}
+```
+
+#### Status (`String`)
+
+This is an HTTP status. It must be a string containing a 3-digit integer result code followed by a reason phrase. For example, `200 OK`.
+
+#### Headers (`[(String, String)]`)
+
+The headers is an array of tuples containing the key and value for each HTTP header for the server to send in the returned order.
+
+#### Body (`HttpOutputStream`)
+
+Must be an HttpOutputStream.
 


### PR DESCRIPTION
As pointed out in issue #2 and issue #9 issues, String is not an alternative for the request and response body type

Neither the response or request body are limited to string data. Data also does not need to be sent all at once, but can be sent as a continues stream, which needs to be supported as a lot of web applications takes advantage of this to do realtime communication.